### PR TITLE
fix(ci): use adfinisbot for release

### DIFF
--- a/.github/workflows/collection.yaml
+++ b/.github/workflows/collection.yaml
@@ -1,13 +1,12 @@
 ---
-
 name: Build and deploy Collection on Ansible Galaxy
 on:
   release:
     types:
       - published
-      - created
     tags:
       - 'v*'
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -1,5 +1,4 @@
 ---
-
 # runs on each push to main and is responsible for creating new tags/releases
 name: Create Semantic Release
 
@@ -23,5 +22,4 @@ jobs:
         uses: go-semantic-release/action@v1.23
         with:
           allow-initial-development-versions: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.ADFINISBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This should fix our problem with the automatic release Action.

We have to use the @adfinisbot because GitHub doesn't start the release action if the release is created with a github_token to prevent loops.