### PR TITLE
ci(dependabot): fix wrong directory scope for gitsubmodule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,6 @@ updates:
     schedule:
       interval: daily
   - package-ecosystem: gitsubmodule
-    directory: "/roles"
+    directory: "/"
     schedule:
       interval: daily


### PR DESCRIPTION
This fixes the issue that Dependabot doesn't update the git submodules in the repository.