### PR TITLE
chore(playbooks): manage_clients/jobs delegate_to Director, default(omit)

### DIFF
--- a/playbooks/manage_clients_playbook.yml
+++ b/playbooks/manage_clients_playbook.yml
@@ -29,24 +29,24 @@
         - manage_clients
         - manage_clients::setup
 
+
+# first the necessary vars from every client in the `filedaemons` group are collected,
+# which are required to deploy the clients with the bareos_dir role.
+# as the Bareos Director is not supposed to be part of any `filedaemons` group,
+# `delegate_to` is used to call the Director with the bareos_dir role, even
+# when it's outside of the Ansible -l/--limit scope.
+#
+# the play uses `run_once` so it's only executed on the first host,
+# which then loops over the `filedaemons` group.
 - name: Deploy Filedaemons on Director with the bareos_dir role
-  hosts: directors
+  hosts: all
+  run_once: true
   become: true
   vars:
     _fd_list: []
   pre_tasks:
-    - name: Gather Ansible facts for all Filedaemons
-      ansible.builtin.setup:
-      delegate_to: "{{ item }}"
-      delegate_facts: true
-      loop: "{{ groups['filedaemons'] }}"
-      when:
-        - ansible_limit is undefined or
-          item in groups[ansible_limit]  # only use filedaemons in-scope of --limit/-l
-      tags:
-        - manage_clients
-        - manage_clients::deployment
 
+    # uses `default(omit)` for optional variables
     - name: Create list of Filedaemons to deploy on Director
       ansible.builtin.set_fact:
         _fd_list: >-
@@ -54,17 +54,20 @@
             'name': item,
             'address': client_defaults.address,
             'password': client_defaults.password,
-            'maximum_concurrent_jobs': client_defaults.maximum_concurrent_jobs,
-            'connection_from_director_to_client': client_defaults.connection_from_dir,
-            'connection_from_client_to_director': client_defaults.connection_from_fd,
-            'heartbeat': client_defaults.heartbeat,
-            'enabled': client_defaults.enabled}]
+            'maximum_concurrent_jobs': client_defaults.maximum_concurrent_jobs | default(omit),
+            'connection_from_director_to_client': client_defaults.connection_from_dir | default(omit),
+            'connection_from_client_to_director': client_defaults.connection_from_fd | default(omit),
+            'heartbeat': client_defaults.heartbeat | default(omit),
+            'enabled': client_defaults.enabled | default(omit) }]
           }}
       loop: "{{ groups['filedaemons'] }}"
       tags:
         - manage_clients
         - manage_clients::deployment
       when:
+        - client_defaults is defined
+        - client_defaults.address is defined
+        - client_defaults.password is defined
         - ansible_limit is undefined or
           item in groups[ansible_limit]  # only use filedaemons in-scope of --limit/-l
         - hostvars[item].bareos_fd_configuration is undefined  # let's you set exceptions on group/host_vars level
@@ -81,6 +84,8 @@
         - ansible_limit is undefined or
           item in groups[ansible_limit]  # only use filedaemons in-scope of --limit/-l
         - hostvars[item].bareos_fd_configuration is defined  # let's you set exceptions on group/host_vars level
+        - hostvars[item].bareos_fd_configuration.name is defined
+        - hostvars[item].bareos_fd_configuration.password is defined
 
     - name: Register client list
       ansible.builtin.set_fact:
@@ -89,8 +94,11 @@
         - manage_clients
         - manage_clients::deployment
 
-  roles:
-    - role: bareos_dir
+  tasks:
+    - name: Delegate bareos_dir role to Director
+      ansible.builtin.import_role:
+        name: bareos_dir
+      delegate_to: "{{ groups['directors'][0] }}"  # workaround to call the director
       tags:
         - manage_clients
         - manage_clients::deployment

--- a/playbooks/manage_jobs_playbook.yml
+++ b/playbooks/manage_jobs_playbook.yml
@@ -6,12 +6,26 @@
   gather_facts: true
   tags: always
 
+
+# first the necessary vars from every client in the `filedaemons` group are collected,
+# which are required to deploy the job(s) for each client on the Bareos Director with the bareos_dir role.
+# as the Bareos Director is not supposed to be part of any `filedaemons` group,
+# `delegate_to` is used to call the Director with the bareos_dir role, even
+# when it's outside of the Ansible -l/--limit scope.
+#
+# the play uses `run_once` so it's only executed on the first host,
+# which then loops over the `filedaemons` group.
+
 - name: Create jobs on Director for every client in host_group filedaemons
-  hosts: directors
+  hosts: all
+  run_once: true
   become: true
   vars:
     _job_list: []
+
   pre_tasks:
+
+    # uses `default(omit)` for optional variables
     - name: Create job list for all FDs with defined standard values (group_vars)
       ansible.builtin.set_fact:
         _job_list: >-
@@ -19,15 +33,22 @@
             'name': job_defaults.name+'_'+item,
             'client': item,
             'pool': job_defaults.pool,
-            'type': job_defaults.type,
-            'messages': job_defaults.messages,
-            'jobdefs': job_defaults.jobdefs,
-            'storage': job_defaults.storage,
-            'schedule': job_defaults.schedule}]
+            'full_backup_pool': job_defaults.full_backup_pool | default(omit),
+            'differential_backup_pool': job_defaults.differential_backup_pool | default(omit),
+            'incremental_backup_pool': job_defaults.incremental_backup_pool | default(omit),
+            'max_full_interval': job_defaults.max_full_interval | default(omit),
+            'max_diff_interval': job_defaults.max_diff_interval | default(omit),
+            'type': job_defaults.type | default(omit),
+            'messages': job_defaults.messages | default(omit),
+            'jobdefs': job_defaults.jobdefs | default(omit),
+            'storage': job_defaults.storage | default(omit),
+            'schedule': job_defaults.schedule | default(omit) }]
           }}
       loop: "{{ groups['filedaemons'] }}"
       tags: manage_jobs
       when:
+        - job_defaults is defined
+        - job_defaults.pool is defined
         - ansible_limit is undefined or
           item in groups[ansible_limit]  # only use filedaemons in-scope of --limit/-l
         - hostvars[item].bareos_fd_jobs is undefined  # let's you set exceptions on group/host_vars level
@@ -48,6 +69,10 @@
         bareos_dir_jobs: "{{ _job_list }}"
       tags: manage_jobs
 
-  roles:
-    - role: bareos_dir
-      tags: manage_jobs
+  tasks:
+    - name: Delegate bareos_dir role to Director
+      ansible.builtin.import_role:
+        name: bareos_dir
+      delegate_to: "{{ groups['directors'][0] }}"  # workaround to call the director
+      tags:
+        - manage_jobs


### PR DESCRIPTION
Use `delegate_to` to be able to call Bareos Director outside of Ansible `-l/--limit` scope.
Add `default(omit)` to optional variables for global default settings