### PR TITLE
feat(playbooks): switch groups[ansible_limit] to ansible_play_hosts

### DIFF
--- a/playbooks/manage_clients_playbook.yml
+++ b/playbooks/manage_clients_playbook.yml
@@ -65,10 +65,10 @@
         - manage_clients
         - manage_clients::deployment
       when:
-        - client_defaults is defined
-        - client_defaults.address is defined
-        - client_defaults.password is defined
-        - item in ansible_play_hosts  # allows limiting to filedaemons in-scope of --limit-l
+        - hostvars[item].client_defaults is defined  # recommended to set client_defaults in group_vars/all
+        - hostvars[item].client_defaults.address is defined
+        - hostvars[item].client_defaults.password is defined
+        - item in ansible_play_hosts  # allows limiting to filedaemons in-scope of --limit/-l
         - hostvars[item].bareos_fd_configuration is undefined  # let's you set exceptions on group/host_vars level
 
     - name: Add Filedaemons to list which have separate host_vars defined
@@ -80,7 +80,7 @@
         - manage_clients
         - manage_clients::deployment
       when:
-        - item in ansible_play_hosts  # allows limiting to filedaemons in-scope of --limit-l
+        - item in ansible_play_hosts  # allows limiting to filedaemons in-scope of --limit/-l
         - hostvars[item].bareos_fd_configuration is defined  # let's you set exceptions on group/host_vars level
         - hostvars[item].bareos_fd_configuration.name is defined
         - hostvars[item].bareos_fd_configuration.password is defined

--- a/playbooks/manage_jobs_playbook.yml
+++ b/playbooks/manage_jobs_playbook.yml
@@ -52,9 +52,9 @@
       loop: "{{ groups['filedaemons'] }}"
       tags: manage_jobs
       when:
-        - job_defaults is defined
-        - job_defaults.pool is defined
         - item in ansible_play_hosts  # allows limiting to filedaemons in-scope of --limit-l
+        - hostvars[item].job_defaults is defined  # recommended to set job_defaults in group_vars/all
+        - hostvars[item].job_defaults.pool is defined
 
         # let's you set exceptions on group/host_vars level.
         # when bareos_fd_jobs_append is set to true (default is false) on group/host level,


### PR DESCRIPTION
This solves a big problem with Ansible's `-l/--limit` parameter as the former approach only supported actual groups. 

This allows us to target all hosts, without `-l/--limit` parameter or also single hosts instead of a full group.